### PR TITLE
Exception -> Receiver not registered: org.apache.cordova.smsotpautofill.SmsOtpAutofill

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This plugin extracts the OTP of required length from the received SMS.
 ### Installation
 
 ```
-cordova plugin add cordova-plugin-otp-autofill
+cordova plugin add cordova-plugin-otp-autofill-v2
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# cordova-plugin-otp-autofill
+# cordova-plugin-otp-autofill-v2
 
 
 ### Description

--- a/package.json
+++ b/package.json
@@ -1,16 +1,16 @@
 {
-  "name": "cordova-plugin-otp-autofill",
-  "version": "0.0.2",
+  "name": "cordova-plugin-otp-autofill-v2",
+  "version": "0.0.3",
   "description": "An Android Cordova plugin that auto populates otp received through sms.",
   "cordova": {
-    "id": "cordova-plugin-otp-autofill",
+    "id": "cordova-plugin-otp-autofill-v2",
     "platforms": [
       "android"
     ]
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/akhilvenkateswaran/cordova-plugin-otp-autofill.git"
+    "url": "git+https://github.com/joebalan-git/cordova-plugin-otp-autofill-v2.git"
   },
   "keywords": [
     "SMS",
@@ -26,10 +26,10 @@
     "version":">=3.0.0"
   }
   ,
-  "author": "Akhil Venkateswaran <akhil.venkateswaran@gmail.com>",
+  "author": "Joe Balan <joe.balan@codectrlsolutions.com>",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/akhilvenkateswaran/cordova-plugin-otp-autofill.git/issues"
+    "url": "https://github.com/joebalan-git/cordova-plugin-otp-autofill-v2.git/issues"
   },
-  "homepage": "https://github.com/akhilvenkateswaran/cordova-plugin-otp-autofill.git"
+  "homepage": "https://github.com/joebalan-git/cordova-plugin-otp-autofill-v2.git"
 }

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
         xmlns:android="http://schemas.android.com/apk/res/android"
-        id="cordova-plugin-otp-autofill" version="0.0.2">
+        id="cordova-plugin-otp-autofill-v2" version="0.0.3">
     <name>SmsOTPAutoFillPlugin</name>
 
     <description>An Android Cordova plugin that auto populates otp received through sms.</description>
     <license>MIT</license>
 
     <keywords>cordova,android,sms,otp,autofill,autoverify</keywords>
-    <repo>https://github.com/akhilvenkateswaran/cordova-plugin-otp-autofill.git</repo>
-    <issue>https://github.com/akhilvenkateswaran/cordova-plugin-otp-autofill.git/issues</issue>
+    <repo>https://github.com/joebalan-git/cordova-plugin-otp-autofill-v2.git</repo>
+    <issue>https://github.com/joebalan-git/cordova-plugin-otp-autofill-v2.git/issues</issue>
   
     <engines>
         <engine name="cordova" version=">=3.0.0"/>

--- a/src/android/SmsOtpAutofill.java
+++ b/src/android/SmsOtpAutofill.java
@@ -84,33 +84,49 @@ public class SmsOtpAutofill extends CordovaPlugin {
     private void startCountDownTimer() {
 
         registerReceiver();
-        countDownTimer = new CountDownTimer(timeout*1000, 1000) {
-            @Override
-            public void onTick(long l) {
-
-            }
-
-            @Override
-            public void onFinish() {
-                unregisterReceiver();
-                updateCallbackStatus(otpCallbackContext,"Resend OTP");
-            }
-        };
-
-        countDownTimer.start();
-
+        startCounter();
     }
 
-    private void registerReceiver() {
+    private void startCounter() {
+      countDownTimer = new CountDownTimer(timeout*1000, 1000) {
+          @Override
+          public void onTick(long l) {
+
+          }
+
+          @Override
+          public void onFinish() {
+              unregisterReceiver();
+              updateCallbackStatus(otpCallbackContext,"Resend OTP");
+          }
+      };
+
+      countDownTimer.start();
+    }
+
+  private void registerReceiver() {
         IntentFilter intentFilter = new IntentFilter();
         intentFilter.addAction(BroadcastAction);
+        unregisterBroadcastReceiver();
+        if(null != countDownTimer){
+          countDownTimer.cancel();
+        }
+        startCounter();
         cordova.getActivity().getApplicationContext().registerReceiver(broadcastReceiver,intentFilter);
     }
 
     private void unregisterReceiver() {
         IntentFilter intentFilter = new IntentFilter();
         intentFilter.addAction(BroadcastAction);
+        unregisterBroadcastReceiver();
+    }
+
+    private void unregisterBroadcastReceiver(){
+      try{
         cordova.getActivity().getApplicationContext().unregisterReceiver(broadcastReceiver);
+      } catch(Exception e) {
+        e.printStackTrace();
+      }
     }
 
     private BroadcastReceiver broadcastReceiver = new BroadcastReceiver() {


### PR DESCRIPTION
In case if the plugin causes app crash due to below error. This solution will alteast avoid the app crash.

E/AndroidRuntime: FATAL EXCEPTION: JavaBridge
    Process: com.codectrlsolutions.ecommerce, PID: 3470
    java.lang.IllegalArgumentException: Receiver not registered: org.apache.cordova.smsotpautofill.SmsOtpAutofill$2@72dd70b
        at android.app.LoadedApk.forgetReceiverDispatcher(LoadedApk.java:1568)
        at android.app.ContextImpl.unregisterReceiver(ContextImpl.java:1799)
        at android.content.ContextWrapper.unregisterReceiver(ContextWrapper.java:779)
        at org.apache.cordova.smsotpautofill.SmsOtpAutofill.unregisterReceiver(SmsOtpAutofill.java:113)
        at org.apache.cordova.smsotpautofill.SmsOtpAutofill.access$000(SmsOtpAutofill.java:20)
        at org.apache.cordova.smsotpautofill.SmsOtpAutofill$1.onFinish(SmsOtpAutofill.java:95)
        at android.os.CountDownTimer$1.handleMessage(CountDownTimer.java:142)
        at android.os.Handler.dispatchMessage(Handler.java:106)
        at android.os.Looper.loopOnce(Looper.java:210)
        at android.os.Looper.loop(Looper.java:299)
        at android.os.HandlerThread.run(HandlerThread.java:67)